### PR TITLE
Avalonia: Update Polish Translation

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -588,5 +588,6 @@
   "SettingsTabGraphicsPreferredGpuTooltip": "Wybierz kartę graficzną, która będzie używana z backendem graficznym Vulkan.\n\nNie wpływa na GPU używane przez OpenGL.\n\nW razie wątpliwości ustaw flagę GPU jako \"dGPU\". Jeśli żadnej nie ma, pozostaw nietknięte.",
   "SettingsAppRequiredRestartMessage": "Wymagane Zrestartowanie Ryujinx",
   "SettingsGpuBackendRestartMessage": "Zmieniono ustawienia Backendu Graficznego lub GPU. Będzie to wymagało ponownego uruchomienia",
-  "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?"
+  "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?",
+  "VolumeShort": "Głoś."
 }


### PR DESCRIPTION
Adding the shortened "volume" string from recent changes.

You need the period there otherwise it could be read as "Głoś" -> "Preach".